### PR TITLE
feat: adopt apple liquid glass design

### DIFF
--- a/src/app/blogs/layout.tsx
+++ b/src/app/blogs/layout.tsx
@@ -7,7 +7,7 @@ export default function BlogsLayout({
     children: React.ReactNode;
 }) {
     return (
-        <div className="flex min-h-screen flex-col">
+        <div className="glass flex min-h-screen flex-col">
             <Header />
             <main className="flex-1">
                 {children}
@@ -15,4 +15,4 @@ export default function BlogsLayout({
             <Footer />
         </div>
     );
-} 
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,7 +55,7 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply text-foreground bg-gradient-to-br from-white/60 via-white/30 to-white/60 dark:from-gray-900/60 dark:via-gray-900/30 dark:to-gray-900/60;
     font-feature-settings:
       'rlig' 1,
       'calt' 1;
@@ -81,5 +81,11 @@ html {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@layer components {
+  .glass {
+    @apply bg-white/30 dark:bg-gray-900/30 backdrop-blur-xl border border-white/40 dark:border-gray-700/60 rounded-xl shadow-lg;
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import { About } from '@/components/sections/about';
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="glass flex min-h-screen flex-col">
       <Header />
       <main className="flex-1">
         <Hero />

--- a/src/components/ui/footer.tsx
+++ b/src/components/ui/footer.tsx
@@ -7,7 +7,7 @@ export function Footer() {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="border-t border-gray-200 dark:border-gray-800 bg-background">
+    <footer className="glass border-t">
       <div className="container py-8 md:py-12">
         <div className="flex flex-col md:flex-row justify-between items-center">
           <div className="mb-4 md:mb-0">

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -45,7 +45,7 @@ export function Header() {
 
   return (
     <>
-      <header className="sticky top-0 z-40 w-full border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950 bg-opacity-90 dark:bg-opacity-90 backdrop-blur-sm">
+      <header className="glass sticky top-0 z-40 w-full border-b">
         <div className="container flex h-16 items-center justify-between">
           <div className="flex items-center gap-6 md:gap-10">
             <Link href="/" className="font-bold text-xl">


### PR DESCRIPTION
## Summary
- add `glass` utility for translucent, blurred surfaces
- apply apple-like glass styling to headers, footers, and page layouts
- use gradient background to complement liquid glass aesthetic

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint -- --no-interactive`
- `npm run build` (fails: Failed to fetch font `Geist` – network issue)


------
https://chatgpt.com/codex/tasks/task_e_689736ed40f08328a1811fe246ce764b